### PR TITLE
make: Don't add fPIC if windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@ PREFIX			:= /usr/local
 LIBDIR			:= $(PREFIX)/lib
 INCLUDEDIR		:= $(PREFIX)/include
 
+ifeq ($(OS),Windows_NT)
+OPTFLAGS		:= -g -O3 -Wall
+else
 OPTFLAGS		:= -fPIC -g -O3 -Wall
+endif
 override CFLAGS		:= $(OPTFLAGS) $(CFLAGS)
 override CXXFLAGS	:= $(OPTFLAGS) -DUSE_PTHREADS -DNDEBUG -I. -Isrc -Irubberband $(CXXFLAGS)
 override LDFLAGS	:= -pthread $(LDFLAGS)


### PR DESCRIPTION
pic options are a no-op with mingw-w64 gcc, but clang throws an error.

Don't know if there's a better way atm.

Relevant https://github.com/m-ab-s/media-autobuild_suite/issues/1608